### PR TITLE
fix: fix spacebar in studio in MIT layout

### DIFF
--- a/boards/arm/keyboardio_preonic/keyboardio_preonic-layouts.dtsi
+++ b/boards/arm/keyboardio_preonic/keyboardio_preonic-layouts.dtsi
@@ -155,8 +155,9 @@
 
         complete;
 
-        // Ortho has keys 56 and 57
-        // MIT has 56 and a gap where 57 would be
+        // Ortho has keys 56 and 57 (the reference layout)
+        // With MIT, the single spacebar matches 57 (the right-hand
+        // key) and there's a gap where 56 would be.
 
         mit_map: mit_map {
             physical-layout = <&mit_layout>;
@@ -166,7 +167,7 @@
                 , <15 16 17 18 19 20 21 22 23 24 25 26>
                 , <27 28 29 30 31 32 33 34 35 36 37 38>
                 , <39 40 41 42 43 44 45 46 47 48 49 50>
-                , <51 52 53 54 55 56 62 57 58 59 60 61>
+                , <51 52 53 54 55 62 56 57 58 59 60 61>
                 ;
         };
 


### PR DESCRIPTION
Fix the behavior of the 2u spacebar when using the MIT layout in ZMK Studio.

I was operating under the assumption that it shared its mapping with the left 1u key. That was incorrect; it shares its behavior with the right key instead.

This time, I took the time to swap my switches and validate the behavior! I also have a confirmation from another user on Discord that this behavior is correct.