### PR TITLE
Improve encoder support

### DIFF
--- a/boards/arm/keyboardio_preonic/keyboardio_preonic.dts
+++ b/boards/arm/keyboardio_preonic/keyboardio_preonic.dts
@@ -86,8 +86,9 @@
 			;
 	};
 
-    // The pinout for the keyboard suggests that there are 3 available encoders.
-    // However, the physical keyboard only has one...hmm.
+    // There are 3 available spots where an encoder can be installed.
+    // However, the default factory layout only uses one, so by default,
+    // only one is enabled here.
 
     encoder1: encoder1 {
         compatible = "alps,ec11";

--- a/boards/arm/keyboardio_preonic/keyboardio_preonic.dts
+++ b/boards/arm/keyboardio_preonic/keyboardio_preonic.dts
@@ -94,7 +94,7 @@
         compatible = "alps,ec11";
         a-gpios = <&gpio1 10 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
         b-gpios = <&gpio1 11 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
-        steps = <24>;
+        steps = <80>;
         status = "disabled";
     };
 
@@ -102,7 +102,7 @@
         compatible = "alps,ec11";
         a-gpios = <&gpio1 3  (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
         b-gpios = <&gpio0 15 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
-        steps = <24>;
+        steps = <80>;
         status = "disabled";
     };
 
@@ -110,7 +110,7 @@
         compatible = "alps,ec11";
         a-gpios = <&gpio0 28 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
         b-gpios = <&gpio0 2  (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
-        steps = <24>;
+        steps = <80>;
         status = "okay";
     };
 
@@ -118,7 +118,7 @@
         compatible = "zmk,keymap-sensors";
         status = "okay";
         sensors = <&encoder3>;
-        triggers-per-rotation = <12>;
+        triggers-per-rotation = <20>;
     };
 };
 

--- a/boards/arm/keyboardio_preonic/keyboardio_preonic.dts
+++ b/boards/arm/keyboardio_preonic/keyboardio_preonic.dts
@@ -91,24 +91,24 @@
 
     encoder1: encoder1 {
         compatible = "alps,ec11";
-        a-gpios = <&gpio1 11 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
-        b-gpios = <&gpio1 10 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+        a-gpios = <&gpio1 10 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+        b-gpios = <&gpio1 11 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
         steps = <24>;
         status = "disabled";
     };
 
     encoder2: encoder2 {
         compatible = "alps,ec11";
-        a-gpios = <&gpio1 15 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
-        b-gpios = <&gpio0 3  (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+        a-gpios = <&gpio1 3  (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+        b-gpios = <&gpio0 15 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
         steps = <24>;
         status = "disabled";
     };
 
     encoder3: encoder3 {
         compatible = "alps,ec11";
-        a-gpios = <&gpio0 2  (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
-        b-gpios = <&gpio0 28 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+        a-gpios = <&gpio0 28 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+        b-gpios = <&gpio0 2  (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
         steps = <24>;
         status = "okay";
     };


### PR DESCRIPTION
Fix a couple of quirks about the encoder support I introduced in #1:

## Encoder Direction

ZMK's encoder support uses "increment" and "decrement" nomenclature, like this:

`&inc_dec_kp C_VOLUME_UP C_VOLUME_DOWN`

Previously, the A and B pins were reversed in the config so the "increment" action was in the second position in this macro instead of the first one.

This is purely semantics - the keymaps would work either way - but this swap helps the keymap to match examples from ZMK docs and other keyboards more closely.

## Resolution

The `steps` and `triggers-per-rotation` seemed to be incorrect; the encoder was usually sending two keystrokes per single, tactile bump.

I don't know the exact model number or datasheet of the encoder used by this keyboard, so I had to guess and check at the proper values for these two settings. I settled on these values for a couple different reasons:

1. Recommendation by @ujl123, who got the LEDs working in my previous PR #1
2. Matches the defaults in the example code on the [ZMK docs for encoders](https://zmk.dev/docs/development/hardware-integration/encoders)
3. Recommendation on the ZMK Discord (see below):

> You should probably stick with the same 80 steps/20 triggers-per-rotation most generic Alps-clone encoders use to start, unless you can provide a specific datasheet for yours.

Using these values, I do still experience an occasional "drop" or missed input from the encoder (maybe once out of every 15-20 times), but most of the time one tactile bump sends one keypress. In my opinion, that's a better experience overall.